### PR TITLE
Fix method chaining in initLayout, closes #2

### DIFF
--- a/leaflet.responsive.popup.js
+++ b/leaflet.responsive.popup.js
@@ -41,8 +41,8 @@ L.ResponsivePopup = L.Popup.extend({
 
 		L.DomEvent
 			.disableClickPropagation(wrapper)
-			.disableScrollPropagation(this._contentNode)
-			.on(wrapper, 'contextmenu', L.DomEvent.stopPropagation);
+			.on(wrapper, 'contextmenu', L.DomEvent.stopPropagation)
+			.disableScrollPropagation(this._contentNode);
 
 		if(this.options.hasTip) {
 			this._tipContainer = L.DomUtil.create('div', prefix + '-tip-container', container);


### PR DESCRIPTION
Fix method chaining which caused the exception **"Uncaught TypeError: Cannot read property 'on' of undefined"**  in `_initLayout `function
to support new versions of leaflet 1.1+